### PR TITLE
Keep metadata from attrs

### DIFF
--- a/src/marshmallow_annotations/ext/attrs.py
+++ b/src/marshmallow_annotations/ext/attrs.py
@@ -61,6 +61,9 @@ class AttrsConverter(BaseConverter):
             # into __init__ -- even if the user told us otherwise
             kwargs["dump_only"] = True
 
+        if attr.metadata:
+            kwargs.update(attr.metadata)
+
     def _ensure_all_hints_are_attribs(self, target, ignore):
         # This would happen if an attrs handled class was subclassed by
         # a plain ol' python class and added more non-ignored type hinted

--- a/test/ext/test_attrs.py
+++ b/test/ext/test_attrs.py
@@ -23,6 +23,8 @@ class SomeClass:
     c: int = attr.ib(default=1, init=False)
     # non-required, missing is 1
     d: int = attr.ib(default=1)
+    # Include metadata
+    e: str = attr.ib(default="", metadata={"hi": "world"})
 
 
 def test_properly_converts_attrs_class_to_schema(registry_):
@@ -50,7 +52,7 @@ def test_dumps_all_attributes(registry_):
     s = SomeClassSchema()
     result = s.dump(SomeClass(a=99))  # type: ignore
 
-    expected = {"a": 99, "b": 1, "c": 1, "d": 1}
+    expected = {"a": 99, "b": 1, "c": 1, "d": 1, "e": ""}
     assert not result.errors
     assert result.data == expected
 
@@ -67,3 +69,14 @@ def test_cant_convert_non_attrs_subclass(registry_):
                 target = SomeSubclass
 
     assert "x" in str(excinfo.value)
+
+
+def test_metadata_included(registry_):
+    class SomeClassSchema(AttrsSchema):
+        class Meta:
+            registry = registry_
+            target = SomeClass
+
+    s = SomeClassSchema()
+    assert s.fields["e"].metadata.keys() == {"hi"}
+    assert s.fields["e"].metadata["hi"] == "world"


### PR DESCRIPTION
[`Attrs`](https://www.attrs.org/en/stable/api.html#attr.ib) allows to specify `metadata` and also marshmallow [`Fields`](https://marshmallow.readthedocs.io/en/2.x-line/api_reference.html#module-marshmallow.fields) can hold `metadata`.  Other projects like [`apispec`](https://apispec.readthedocs.io/en/stable/api_core.html#apispec.APISpec.definition) use these and it would be great, if this project would support them.