### PR TITLE
Handle generating field for schema that isn't defined yet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,9 @@ Session.vim
 .netrwhist
 *~
 # auto-generated tag files
-tags
+tags.lock
+tags.temp
 
 # End of https://www.gitignore.io/api/python,vim
+
+*.ipynb

--- a/src/marshmallow_annotations/base.py
+++ b/src/marshmallow_annotations/base.py
@@ -34,7 +34,8 @@ class AbstractConverter(ABC):
         opts: ConfigOptions = None,
         *,
         field_name: str = None,
-        target: type = None
+        target: type = None,
+        allow_thunked: bool = True
     ) -> FieldABC:
         """
         Used to convert a type hint into a :class:`~marshmallow.base.FieldABC`
@@ -51,6 +52,7 @@ class AbstractConverter(ABC):
         target: type,
         ignore: AbstractSet[str] = frozenset([]),  # noqa: B008
         configs: NamedConfigs = None,
+        allow_thunked: bool = True
     ) -> GeneratedFields:
         """
         Used to transform a type with annotations into a dictionary mapping

--- a/src/marshmallow_annotations/fields.py
+++ b/src/marshmallow_annotations/fields.py
@@ -1,0 +1,112 @@
+from marshmallow.fields import Field, missing_
+
+from marshmallow_annotations.base import AbstractConverter, ConfigOptions
+
+
+class ThunkedField(Field):
+    def __init__(
+        self,
+        converter: AbstractConverter,
+        typehint: type,
+        opts: ConfigOptions = None,
+        *,
+        field_name: str = None,
+        target: type = None,
+    ) -> None:
+        # we intentionally do not call the super constructor
+        self._converter = converter
+        self._typehint = typehint
+        self._opts = opts
+        self._field_name = field_name
+        self._target = target
+        self.__inner_field = None
+        self._parent = None
+        self._name = None
+
+    @property
+    def _inner_field(self):
+        if self.__inner_field is None:
+            self.__inner_field = self._converter.convert(
+                self._typehint,
+                self._opts,
+                field_name=self._field_name,
+                target=self._target,
+                allow_thunked=False,
+            )
+
+            self.__inner_field._add_to_schema(self._parent, self._name)
+
+        return self.__inner_field
+
+    def serialize(self, attr, obj, accessor=None):
+        return self._inner_field.serialize(attr, obj, accessor)
+
+    def deserialize(self, value, attr=None, data=None):
+        return self._inner_field.deserialize(value, attr, data)
+
+    # proxy these as well just in case someone goes poking around
+    def _serialize(self, value, attr, obj):
+        return self._inner_field._serialize(self, value, attr, obj)
+
+    def _deserialize(self, value, attr, data):
+        return self._inner_field._deserialize(value, attr, data)
+
+    def _inner_field_property(prop_name):
+        getter = lambda self: getattr(self._inner_field, prop_name)
+        setter = lambda self, value: setattr(self._inner_field, prop_name, value)
+        return property(getter, setter)
+
+    default = _inner_field_property("default")
+    attribute = _inner_field_property("attribute")
+    load_from = _inner_field_property("load_from")
+    dump_to = _inner_field_property("dump_to")
+    validate = _inner_field_property("validate")
+    required = _inner_field_property("required")
+    load_only = _inner_field_property("load_only")
+    dump_only = _inner_field_property("dump_only")
+    missing = _inner_field_property("missing")
+    metadata = _inner_field_property("metadata")
+
+    del _inner_field_property
+
+    @property
+    def parent(self):
+        if self.__inner_field is None:
+            return self._parent
+        return self._inner_field.parent
+
+    @parent.setter
+    def parent(self, value):
+        if self.__inner_field is None:
+            self._parent = value
+        self._inner_field.parent = value
+
+    @property
+    def name(self):
+        if self.__inner_field is None:
+            return self._name
+        return self._inner_field.name
+
+    @name.setter
+    def name(self, value):
+        if self.__inner_field is None:
+            self._name = value
+        self._inner_field.name = value
+
+    def __repr__(self):
+        if self._inner_field is None:
+            return f"ThunkedField(UNINITIALIZED)"
+
+        return f"ThunkedField({repr(self._inner_field)})"
+
+    def get_value(self, attr, obj, accessor=None, default=missing_):
+        return self._inner_field.get_value(attr, obj, accessor, default)
+
+    def _validate(self, value):
+        return self._inner_field._validate(value)
+
+    def fail(self, key, **kwargs):
+        return self._inner_field.fail(key, **kwargs)
+
+    def _validate_missing(self, value):
+        return self._inner_field._validate_missing(value)


### PR DESCRIPTION
Closes #5 

Adding a new parameter to `AbstractConverter` is probably a breaking change :/ -- but can use the upgrade to Marshmallow 3 as an excuse to also bump major version. :eyes: 

Anyways, idea here is that when we are generating a schema if we encounter a field that we don't know about yet, we can just create a kind of thunk field (appropriately named `ThunkedField`) that delays creating the actual field until it's requested, and then caches that field.

The `ThunkedField` will proxy all operations to the underlying field, creating it if necessary. This is potentially dangerous if there's a marshmallow plugin that'll poke at the created field _BEFORE_ the other schema is created.

This first pass implementation actually improperly handles lists, optionals, etc by just generating thunks for them all since it happens pretty early in `_get_field_from_typehint`, but as a first pass works pretty well. Fixing this might require additionally updating `TypeRegistry.get` to accept an additional argument or adding a `get_or_thunk` method (which is probably better) in which case the `ThunkedField` can carry less information, just what the `FieldFactory` delegate declares

Risks (setting aside the new parameter thing):

The following would now generate a schema but fail at first serialization attempt -- rather than eagerly fail:

```python
class Foo:
    bar: List["bar"] # WHOOPS!

class Bar:
    pass
```

Possible solution: Push a `__THUNKED__: bool` into the field settings and make the end user explicitly declare that a field is to be thunked:

```python
class FooSchema(AnnotationSchema):
    class Meta:
        target = Foo

        class Fields:
            # explicitly opt into thunkiness rather than as the default for everything
            bar = {"__THUNKED__": True}
```

I like the explicit opt-in better, even if it's slightly cumbersome, since it prevents unexpected surprises down the line (leaving only expected surprises). And means that only `convert` needs to change since `convert_all` would receive the opt-in via the field configurations.